### PR TITLE
schedboost: undeclared identifier declared

### DIFF
--- a/libcutils/sched_policy.c
+++ b/libcutils/sched_policy.c
@@ -68,6 +68,7 @@ static int ta_cpuset_fd = -1; // special cpuset for top app
 static int bg_schedboost_fd = -1;
 static int fg_schedboost_fd = -1;
 static int ta_schedboost_fd = -1;
+static int system_bg_schedboost_fd = -1;
 
 #if defined(USE_CPUSETS) || defined(USE_SCHEDBOOST)
 /* Add tid to the scheduling group defined by the policy */


### PR DESCRIPTION
system_bg_schedboost_fd was not declared and gave error.